### PR TITLE
Remove explicit rust-version constraint from src-tauri/Cargo.toml

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["hayayanai"]
 license = ""
 repository = ""
 edition = "2021"
-rust-version = "1.77.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
### Motivation
- Remove the fixed toolchain requirement to avoid pinning the crate to a specific Rust version and improve compatibility across environments.

### Description
- Deleted the `rust-version = "1.77.2"` entry from `src-tauri/Cargo.toml` package metadata.

### Testing
- Ran `cargo check` in the `src-tauri` workspace and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6de60e798832e945ac0e4a170cb4a)